### PR TITLE
feat: expand portfolio with talks and home updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -888,6 +888,7 @@
       "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.49.1"
       },
@@ -964,6 +965,7 @@
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1014,6 +1016,7 @@
       "integrity": "sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.2",
         "@typescript-eslint/types": "8.18.2",
@@ -1220,6 +1223,7 @@
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1288,6 +1292,7 @@
       "integrity": "sha512-5NBVJ50b9iYbzhkLJF0iSWefV4/eWSv+OioRv4kpLKXbnhrQk+wUH/wVt7oxWnZPSrQAuxilckWxZW5BIP3sNQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "allure-js-commons": "3.0.9"
       },
@@ -1671,6 +1676,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2379,6 +2385,7 @@
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2583,6 +2590,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -3842,6 +3850,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4617,6 +4626,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -4805,6 +4815,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4814,6 +4825,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -5817,6 +5829,7 @@
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:3000/',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000/',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,29 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import AboutSections from '../components/AboutSections/AboutSections';
 import LinkButton from '../components/Button/LinkButton';
-import LoadingSpinner from '../components/Loading/Loading';
 
 export default function About() {
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 1000); // Simulate a loading time, adjust as needed
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
   return (
     <main
       className="flex flex-col items-center justify-center min-h-[85vh] p-8"

--- a/src/app/components/AboutSections/AboutSections.tsx
+++ b/src/app/components/AboutSections/AboutSections.tsx
@@ -32,14 +32,13 @@ export default function AboutSections() {
       {sections.map((section, index) => (
         <section
           key={index}
-          className="w-full pb-4 border-b border-yellow-500 cursor-pointer last:border-none px-0 mx-0"
+          className="w-full pb-4 border-b border-yellow-500 last:border-none px-0 mx-0"
           data-testid={`section-${index}`}
-          onClick={() => toggleSection(index)}
         >
-          <header
-            className="flex justify-between items-center"
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
+            className="flex w-full justify-between items-center text-left"
+            onClick={() => toggleSection(index)}
             aria-expanded={openSection === index}
             aria-controls={`section-content-${index}`}
             data-testid={`section-toggle-${index}`}
@@ -59,7 +58,7 @@ export default function AboutSections() {
             >
               ▼
             </span>
-          </header>
+          </button>
           {openSection === index && (
             <div
               className="mt-2 text-gray-300 text-base sm:text-lg"

--- a/src/app/components/Button/LinkButton.tsx
+++ b/src/app/components/Button/LinkButton.tsx
@@ -1,33 +1,44 @@
 import Link from 'next/link';
-import { ButtonHTMLAttributes } from 'react';
+import { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
-interface LinkButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface BaseLinkButtonProps {
   text: string;
-  href?: string;
   extraClasses?: string;
+  className?: string;
 }
 
-export default function LinkButton({
-  text,
-  href,
-  extraClasses = '',
-  ...props
-}: LinkButtonProps) {
+type LinkButtonAsLinkProps = BaseLinkButtonProps &
+  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> & {
+    href: string;
+  };
+
+type LinkButtonAsButtonProps = BaseLinkButtonProps &
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    href?: undefined;
+  };
+
+type LinkButtonProps = LinkButtonAsLinkProps | LinkButtonAsButtonProps;
+
+export default function LinkButton(props: LinkButtonProps) {
+  const { text, extraClasses = '', className } = props;
   const baseClasses =
     'border border-yellow-500 text-yellow-500 rounded-full px-8 py-4 text-lg transition-transform hover:scale-110';
+  const combinedClasses = `${baseClasses} ${extraClasses} ${className ?? ''}`.trim();
 
-  if (href) {
+  if ('href' in props && props.href) {
+    const { href, ...linkProps } = props as LinkButtonAsLinkProps;
+
     return (
-      <Link href={href}>
-        <button className={`${baseClasses} ${extraClasses}`} {...props}>
-          {text}
-        </button>
+      <Link href={href} className={combinedClasses} {...linkProps}>
+        {text}
       </Link>
     );
   }
 
+  const { type = 'button', ...buttonProps } = props as LinkButtonAsButtonProps;
+
   return (
-    <button className={`${baseClasses} ${extraClasses}`} {...props}>
+    <button className={combinedClasses} type={type} {...buttonProps}>
       {text}
     </button>
   );

--- a/src/app/components/Footer/Footer.tsx
+++ b/src/app/components/Footer/Footer.tsx
@@ -1,7 +1,9 @@
 export default function Footer() {
+  const currentYear = new Date().getFullYear();
+
   return (
     <footer
-      className="w-full flex flex-col items-center justify-start gap-6 p-4 border-t border-white/20"
+      className="w-full flex flex-col items-center justify-start gap-6 bg-black p-4 border-t border-white/20"
       data-testid="footer-container"
     >
       <div
@@ -62,7 +64,7 @@ export default function Footer() {
         className="text-sm uppercase text-center px-4"
         data-testid="footer-copyright"
       >
-        © 2024 Bruno Machado.
+        © {currentYear} Bruno Machado.
       </p>
     </footer>
   );

--- a/src/app/components/Header/DesktopMenu.tsx
+++ b/src/app/components/Header/DesktopMenu.tsx
@@ -9,6 +9,7 @@ const menuItems = [
   { name: 'Resume', href: '/resume' },
   { name: 'Skills', href: '/skills' },
   { name: 'Projects', href: '/projects' },
+  { name: 'Talks', href: '/talks' },
   { name: 'Posts', href: '/posts' },
   { name: 'Contacts', href: '/contacts' },
 ];

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import Menu from './Menu';
 
 export default function Header() {
   return (
-    <header className="flex justify-between items-center px-6 py-6 sm:px-24">
+    <header className="sticky top-0 z-50 flex justify-between items-center bg-black px-6 py-6 sm:px-24">
       <Logo />
       <Menu />
     </header>

--- a/src/app/components/Header/MenuItem.tsx
+++ b/src/app/components/Header/MenuItem.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 interface MenuItemProps {
   name: string;
   href: string;
@@ -14,7 +16,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({
   dataTestId,
 }) => {
   return (
-    <a
+    <Link
       href={href}
       aria-label={`Navigate to ${name}`}
       aria-current={isActive ? 'page' : undefined}
@@ -25,6 +27,6 @@ export const MenuItem: React.FC<MenuItemProps> = ({
       onClick={onClick}
     >
       {name}
-    </a>
+    </Link>
   );
 };

--- a/src/app/components/Header/MobileMenu.tsx
+++ b/src/app/components/Header/MobileMenu.tsx
@@ -23,7 +23,7 @@ export default function MobileMenu({ closeMenu }: MobileMenuProps) {
 
   return (
     <nav
-      className="absolute top-16 left-0 w-full h-full p-6 flex flex-col items-start gap-4 lg:hidden bg-background"
+      className="fixed inset-0 z-[60] overflow-y-auto bg-black p-6 pt-24 flex flex-col items-start gap-4 lg:hidden"
       aria-label="Mobile Navigation"
     >
       {menuItems.map((item) => (

--- a/src/app/components/Header/MobileMenu.tsx
+++ b/src/app/components/Header/MobileMenu.tsx
@@ -9,6 +9,7 @@ const menuItems = [
   { name: 'Resume', href: '/resume' },
   { name: 'Skills', href: '/skills' },
   { name: 'Projects', href: '/projects' },
+  { name: 'Talks', href: '/talks' },
   { name: 'Posts', href: '/posts' },
   { name: 'Contacts', href: '/contacts' },
 ];

--- a/src/app/content/experiences.tsx
+++ b/src/app/content/experiences.tsx
@@ -34,6 +34,7 @@ export const EXPERIENCES = [
           'https://res.cloudinary.com/dtglidvcw/image/upload/v1735601960/Portifolio/Avios/avios1.jpg',
           'https://res.cloudinary.com/dtglidvcw/image/upload/v1735601960/Portifolio/Avios/avios2.jpg',
           'https://res.cloudinary.com/dtglidvcw/image/upload/v1735601960/Portifolio/Avios/avios3.jpg',
+          'https://res.cloudinary.com/dtglidvcw/image/upload/v1777031448/Portifolio/Avios/1F6EC3B4-ACF8-4288-BDCE-67F1BF884082_1_105_c_mqjqqi.jpg',
         ],
       },
       {

--- a/src/app/content/projects.tsx
+++ b/src/app/content/projects.tsx
@@ -6,6 +6,7 @@ export interface Project {
   description: string;
   style: ProjectStyle;
   logo: string;
+  logoClassName?: string;
   sections: {
     title: string;
     content: string | JSX.Element;
@@ -13,6 +14,49 @@ export interface Project {
 }
 
 export const PROJECTS: Project[] = [
+  {
+    title: 'Adventurers Guild',
+    description:
+      'A fantasy-themed API portal inspired by Dungeons & Dragons, designed as an interactive codex with guides, documentation, and immersive UI for exploring RPG resources and character systems.',
+    style: 'AdventurersGuild',
+    logo: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1776961236/adventurers/ChatGPT_Image_26_de_mar._de_2026_10_47_27_v6yuq8.png',
+    logoClassName: 'scale-150 sm:scale-[1.85]',
+    sections: [
+      {
+        title: 'Overview',
+        content:
+          'Adventurers Guild is an API portal with an immersive frontend inspired by tabletop RPGs and Dungeons & Dragons, presenting technical resources through a worldbuilding-oriented experience.',
+      },
+      {
+        title: 'Experience Direction',
+        content:
+          'The documentation is treated like an illustrated codex, guiding users through attributes, skills, classes, species, spells, equipment, and character systems in a more exploratory way.',
+      },
+      {
+        title: 'Visual Style',
+        content:
+          'The interface leans into a fantasy codex and medieval grimoire aesthetic, using parchment surfaces, leather tones, ornamental framing, and warm contrast to reinforce the setting.',
+      },
+      {
+        title: 'Current Status',
+        content:
+          'More details, links, and final visual assets will be added later as the project evolves.',
+      },
+      {
+        title: 'Visit the Project',
+        content: (
+          <a
+            href="https://adventurers-guild-api.vercel.app/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Adventurers Guild Website
+          </a>
+        ),
+      },
+    ],
+  },
   {
     title: 'BugBuster',
     description:

--- a/src/app/experience/[companyYear]/page.tsx
+++ b/src/app/experience/[companyYear]/page.tsx
@@ -12,6 +12,13 @@ export default function ExperiencePage() {
   const companyYear = params.companyYear;
 
   const [isLoading, setIsLoading] = useState(true);
+  const [selectedImage, setSelectedImage] = useState<{
+    projectIndex: number;
+    imageIndex: number;
+  } | null>(null);
+  const [expandedProjects, setExpandedProjects] = useState<
+    Record<number, boolean>
+  >({});
 
   useEffect(() => {
     // Simulating a loading delay for demonstration
@@ -26,6 +33,85 @@ export default function ExperiencePage() {
     (exp) =>
       `${exp.company.toLowerCase()}-${exp.year.toLowerCase()}` === companyYear
   );
+
+  const selectedProject =
+    experience && selectedImage
+      ? experience.fullDescription[selectedImage.projectIndex]
+      : null;
+  const selectedGalleryImage =
+    selectedProject && selectedImage
+      ? selectedProject.gallery[selectedImage.imageIndex]
+      : null;
+
+  const showPreviousImage = () => {
+    if (!experience || !selectedImage) {
+      return;
+    }
+
+    const gallery = experience.fullDescription[selectedImage.projectIndex].gallery;
+    const previousIndex =
+      (selectedImage.imageIndex - 1 + gallery.length) % gallery.length;
+
+    setSelectedImage({
+      projectIndex: selectedImage.projectIndex,
+      imageIndex: previousIndex,
+    });
+  };
+
+  const showNextImage = () => {
+    if (!experience || !selectedImage) {
+      return;
+    }
+
+    const gallery = experience.fullDescription[selectedImage.projectIndex].gallery;
+    const nextIndex = (selectedImage.imageIndex + 1) % gallery.length;
+
+    setSelectedImage({
+      projectIndex: selectedImage.projectIndex,
+      imageIndex: nextIndex,
+    });
+  };
+
+  useEffect(() => {
+    if (!experience || !selectedImage) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedImage(null);
+      }
+
+      if (event.key === 'ArrowLeft') {
+        const gallery =
+          experience.fullDescription[selectedImage.projectIndex].gallery;
+        const previousIndex =
+          (selectedImage.imageIndex - 1 + gallery.length) % gallery.length;
+
+        setSelectedImage({
+          projectIndex: selectedImage.projectIndex,
+          imageIndex: previousIndex,
+        });
+      }
+
+      if (event.key === 'ArrowRight') {
+        const gallery =
+          experience.fullDescription[selectedImage.projectIndex].gallery;
+        const nextIndex = (selectedImage.imageIndex + 1) % gallery.length;
+
+        setSelectedImage({
+          projectIndex: selectedImage.projectIndex,
+          imageIndex: nextIndex,
+        });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [experience, selectedImage]);
 
   if (isLoading) {
     return (
@@ -54,110 +140,210 @@ export default function ExperiencePage() {
   }
 
   return (
-    <div
-      className="flex flex-col items-center min-h-screen p-8"
-      data-testid="experience-page"
-      aria-labelledby="experience-page-title"
-    >
-      {/* Título Principal */}
-      <h1
-        className="text-4xl sm:text-5xl font-bold text-yellow-500 mb-8 text-center"
-        id="experience-page-title"
-        data-testid="experience-title"
+    <>
+      <div
+        className="flex flex-col items-center min-h-screen p-8"
+        data-testid="experience-page"
+        aria-labelledby="experience-page-title"
       >
-        {experience.company}
-      </h1>
+        {/* Título Principal */}
+        <h1
+          className="text-4xl sm:text-5xl font-bold text-yellow-500 mb-8 text-center"
+          id="experience-page-title"
+          data-testid="experience-title"
+        >
+          {experience.company}
+        </h1>
 
-      {/* Período e Localização */}
-      <p
-        className="text-base sm:text-lg text-gray-300 text-center mb-2"
-        data-testid="experience-period"
-      >
-        {experience.period}
-      </p>
-      <p
-        className="text-sm sm:text-base text-gray-400 italic mb-12"
-        data-testid="experience-location"
-      >
-        Location: {experience.location}
-      </p>
+        {/* Período e Localização */}
+        <p
+          className="text-base sm:text-lg text-gray-300 text-center mb-2"
+          data-testid="experience-period"
+        >
+          {experience.period}
+        </p>
+        <p
+          className="text-sm sm:text-base text-gray-400 italic mb-12"
+          data-testid="experience-location"
+        >
+          Location: {experience.location}
+        </p>
 
-      {/* Projetos */}
-      <div className="w-full max-w-5xl space-y-12" data-testid="projects-list">
-        {experience.fullDescription.map((project, index) => (
-          <section
-            key={index}
-            data-testid={`project-${index}`}
-            aria-labelledby={`project-title-${index}`}
-          >
-            <h2
-              className="text-2xl sm:text-3xl font-bold text-yellow-500 mb-4"
-              id={`project-title-${index}`}
-              data-testid={`project-title-${index}`}
+        {/* Projetos */}
+        <div className="w-full max-w-5xl space-y-12" data-testid="projects-list">
+          {experience.fullDescription.map((project, index) => (
+            <section
+              key={index}
+              data-testid={`project-${index}`}
+              aria-labelledby={`project-title-${index}`}
             >
-              {project.project}
-            </h2>
-            <p className="text-base sm:text-lg text-gray-300">
-              <strong>Position:</strong> {project.position}
-            </p>
-            <p className="text-base sm:text-lg text-gray-300">
-              <strong>Start:</strong> {project.startDate}
-            </p>
-            <p className="text-base sm:text-lg text-gray-300">
-              <strong>End:</strong> {project.endDate}
-            </p>
-            <p className="mt-4 text-base sm:text-lg text-gray-300">
-              {project.description}
-            </p>
-
-            {/* Galeria */}
-            {project.gallery && project.gallery.length > 0 && (
-              <div
-                className="mt-6"
-                data-testid={`project-gallery-${index}`}
-                aria-labelledby={`gallery-title-${index}`}
+              <h2
+                className="text-2xl sm:text-3xl font-bold text-yellow-500 mb-4"
+                id={`project-title-${index}`}
+                data-testid={`project-title-${index}`}
               >
-                <h3
-                  className="text-xl sm:text-2xl font-bold text-yellow-500 mb-4"
-                  id={`gallery-title-${index}`}
-                  data-testid={`gallery-title-${index}`}
+                {project.project}
+              </h2>
+              <p className="text-base sm:text-lg text-gray-300">
+                <strong>Position:</strong> {project.position}
+              </p>
+              <p className="text-base sm:text-lg text-gray-300">
+                <strong>Start:</strong> {project.startDate}
+              </p>
+              <p className="text-base sm:text-lg text-gray-300">
+                <strong>End:</strong> {project.endDate}
+              </p>
+              <p className="mt-4 text-base sm:text-lg text-gray-300">
+                {project.description}
+              </p>
+
+              {/* Galeria */}
+              {project.gallery && project.gallery.length > 0 && (
+                <div
+                  className="mt-6"
+                  data-testid={`project-gallery-${index}`}
+                  aria-labelledby={`gallery-title-${index}`}
                 >
-                  Gallery
-                </h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                  {project.gallery.map((url, imgIndex) => (
-                    <div
-                      key={imgIndex}
-                      className="relative w-full h-64 sm:h-80"
-                      data-testid={`gallery-image-${index}-${imgIndex}`}
-                    >
-                      <Image
-                        src={url}
-                        alt={`${experience.company} - ${
-                          project.project
-                        } image ${imgIndex + 1}`}
-                        fill
-                        className="object-cover rounded-lg"
-                        priority={imgIndex === 0}
-                      />
+                  <h3
+                    className="text-xl sm:text-2xl font-bold text-yellow-500 mb-4"
+                    id={`gallery-title-${index}`}
+                    data-testid={`gallery-title-${index}`}
+                  >
+                    Gallery
+                  </h3>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                    {(expandedProjects[index]
+                      ? project.gallery
+                      : project.gallery.slice(0, 3)
+                    ).map((url, imgIndex) => (
+                      <button
+                        key={imgIndex}
+                        type="button"
+                        className="relative w-full h-52 sm:h-64 cursor-zoom-in"
+                        data-testid={`gallery-image-${index}-${imgIndex}`}
+                        onClick={() =>
+                          setSelectedImage({
+                            projectIndex: index,
+                            imageIndex: expandedProjects[index]
+                              ? imgIndex
+                              : project.gallery.findIndex(
+                                  (galleryUrl) => galleryUrl === url
+                                ),
+                          })
+                        }
+                        aria-label={`Open ${experience.company} ${project.project} image ${
+                          imgIndex + 1
+                        }`}
+                      >
+                        <Image
+                          src={url}
+                          alt={`${experience.company} - ${
+                            project.project
+                          } image ${imgIndex + 1}`}
+                          fill
+                          className="object-cover rounded-lg transition-transform duration-300 hover:scale-[1.02]"
+                          priority={imgIndex === 0}
+                        />
+                      </button>
+                    ))}
+                  </div>
+
+                  {project.gallery.length > 3 && (
+                    <div className="mt-4 flex justify-center">
+                      <button
+                        type="button"
+                        className="rounded-full border border-yellow-500 px-5 py-2 text-sm text-yellow-400 transition hover:bg-yellow-500 hover:text-black"
+                        onClick={() =>
+                          setExpandedProjects((currentState) => ({
+                            ...currentState,
+                            [index]: !currentState[index],
+                          }))
+                        }
+                        data-testid={`gallery-toggle-${index}`}
+                      >
+                        {expandedProjects[index]
+                          ? 'Show fewer photos'
+                          : 'Show more photos'}
+                      </button>
                     </div>
-                  ))}
+                  )}
                 </div>
-              </div>
-            )}
-          </section>
-        ))}
+              )}
+            </section>
+          ))}
+        </div>
+
+        {/* Botão para voltar ao final */}
+        <Link
+          href="/resume"
+          className="mt-12 text-yellow-500 border border-yellow-500 rounded-full px-4 py-2 text-sm sm:text-base hover:bg-yellow-500 hover:text-gray-900 transition"
+          data-testid="back-to-resume-bottom"
+          aria-label="Back to Resume Timeline"
+        >
+          Back to Timeline
+        </Link>
       </div>
 
-      {/* Botão para voltar ao final */}
-      <Link
-        href="/resume"
-        className="mt-12 text-yellow-500 border border-yellow-500 rounded-full px-4 py-2 text-sm sm:text-base hover:bg-yellow-500 hover:text-gray-900 transition"
-        data-testid="back-to-resume-bottom"
-        aria-label="Back to Resume Timeline"
-      >
-        Back to Timeline
-      </Link>
-    </div>
+      {selectedGalleryImage && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4 sm:p-8"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Expanded experience image"
+          data-testid="experience-image-modal"
+          onClick={() => setSelectedImage(null)}
+        >
+          <div
+            className="relative w-full max-w-6xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="absolute -top-12 right-0 text-white text-3xl leading-none"
+              onClick={() => setSelectedImage(null)}
+              aria-label="Close expanded image"
+              data-testid="experience-image-modal-close"
+            >
+              ×
+            </button>
+
+            <button
+              type="button"
+              className="absolute -left-20 top-1/2 z-10 -translate-y-1/2 flex h-14 w-14 items-center justify-center rounded-full border border-yellow-500 bg-[#2F190F]/80 text-yellow-400 text-2xl backdrop-blur-sm transition-transform hover:scale-105 hover:bg-[#4A2A1A]/85"
+              onClick={showPreviousImage}
+              aria-label="Show previous image"
+              data-testid="experience-image-modal-prev"
+            >
+              ←
+            </button>
+
+            <button
+              type="button"
+              className="absolute -right-20 top-1/2 z-10 -translate-y-1/2 flex h-14 w-14 items-center justify-center rounded-full border border-yellow-500 bg-[#2F190F]/80 text-yellow-400 text-2xl backdrop-blur-sm transition-transform hover:scale-105 hover:bg-[#4A2A1A]/85"
+              onClick={showNextImage}
+              aria-label="Show next image"
+              data-testid="experience-image-modal-next"
+            >
+              →
+            </button>
+
+            <div className="relative w-full h-[70vh] rounded-lg overflow-hidden bg-black">
+              <Image
+                src={selectedGalleryImage}
+                alt={`${experience.company} - ${selectedProject?.project} enlarged image`}
+                fill
+                className="object-contain"
+                sizes="100vw"
+                priority
+              />
+            </div>
+
+            <p className="mt-4 text-sm sm:text-base text-gray-200 text-center">
+              {experience.company} - {selectedProject?.project}
+            </p>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/app/experience/[companyYear]/page.tsx
+++ b/src/app/experience/[companyYear]/page.tsx
@@ -4,14 +4,12 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { EXPERIENCES } from '@/app/content/experiences';
-import LoadingSpinner from '@/app/components/Loading/Loading';
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function ExperiencePage() {
   const params = useParams();
   const companyYear = params.companyYear;
 
-  const [isLoading, setIsLoading] = useState(true);
   const [selectedImage, setSelectedImage] = useState<{
     projectIndex: number;
     imageIndex: number;
@@ -19,15 +17,9 @@ export default function ExperiencePage() {
   const [expandedProjects, setExpandedProjects] = useState<
     Record<number, boolean>
   >({});
-
-  useEffect(() => {
-    // Simulating a loading delay for demonstration
-    const timeout = setTimeout(() => {
-      setIsLoading(false);
-    }, 500);
-
-    return () => clearTimeout(timeout);
-  }, []);
+  const modalCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+  const previousBodyOverflowRef = useRef<string>('');
 
   const experience = EXPERIENCES.find(
     (exp) =>
@@ -77,9 +69,15 @@ export default function ExperiencePage() {
       return;
     }
 
+    previousFocusedElementRef.current = document.activeElement as HTMLElement | null;
+    previousBodyOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    modalCloseButtonRef.current?.focus();
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setSelectedImage(null);
+        return;
       }
 
       if (event.key === 'ArrowLeft') {
@@ -103,6 +101,35 @@ export default function ExperiencePage() {
           projectIndex: selectedImage.projectIndex,
           imageIndex: nextIndex,
         });
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const focusableElements = [
+          modalCloseButtonRef.current,
+          document.querySelector<HTMLButtonElement>(
+            '[data-testid="experience-image-modal-prev"]'
+          ),
+          document.querySelector<HTMLButtonElement>(
+            '[data-testid="experience-image-modal-next"]'
+          ),
+        ].filter((element): element is HTMLButtonElement => element !== null);
+
+        if (focusableElements.length === 0) {
+          return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+        const activeElement = document.activeElement;
+
+        if (event.shiftKey && activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        } else if (!event.shiftKey && activeElement === lastElement) {
+          event.preventDefault();
+          firstElement.focus();
+        }
       }
     };
 
@@ -110,21 +137,10 @@ export default function ExperiencePage() {
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousBodyOverflowRef.current;
+      previousFocusedElementRef.current?.focus();
     };
   }, [experience, selectedImage]);
-
-  if (isLoading) {
-    return (
-      <div
-        className="flex items-center justify-center min-h-screen"
-        data-testid="loading-state"
-        role="status"
-        aria-label="Loading experience details"
-      >
-        <LoadingSpinner />
-      </div>
-    );
-  }
 
   if (!experience) {
     return (
@@ -303,6 +319,7 @@ export default function ExperiencePage() {
               onClick={() => setSelectedImage(null)}
               aria-label="Close expanded image"
               data-testid="experience-image-modal-close"
+              ref={modalCloseButtonRef}
             >
               ×
             </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 'use client';
-import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import LinkButton from './components/Button/LinkButton';
-import LoadingSpinner from './components/Loading/Loading';
 
 const TESTIMONIALS = [
   {
@@ -75,37 +73,14 @@ const educationStatusStyles: Record<string, string> = {
 };
 
 export default function Home() {
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setIsLoading(false);
-    }, 500);
-
-    return () => clearTimeout(timeout);
-  }, []);
-
-  if (isLoading) {
-    return (
-      <div
-        className="flex items-center justify-center min-h-screen"
-        data-testid="loading-state"
-        role="status"
-        aria-label="Loading home page content"
-      >
-        <LoadingSpinner />
-      </div>
-    );
-  }
-
   return (
     <main
-      className="min-h-[85vh] px-6 pt-10 sm:px-8"
+      className="min-h-[85vh] px-6 sm:px-8"
       role="main"
       aria-labelledby="page-title"
     >
       <div className="max-w-6xl mx-auto" data-testid="home-container">
-        <section className="flex min-h-[78vh] sm:min-h-[82vh] items-center justify-center">
+        <section className="flex min-h-screen items-center justify-center">
           <div className="text-center max-w-5xl">
             <h1
               id="page-title"
@@ -133,7 +108,7 @@ export default function Home() {
       </div>
 
       <section
-        className="-mx-6 bg-gradient-to-b from-black via-[rgba(250,204,21,0.88)] to-black px-6 py-10 text-white sm:-mx-8 sm:px-8 sm:py-12"
+        className="-mx-6 flex min-h-screen items-center bg-gradient-to-b from-black via-[rgba(250,204,21,0.88)] to-black px-6 py-10 text-white sm:-mx-8 sm:px-8 sm:py-12"
         aria-labelledby="testimonials-title"
         data-testid="testimonials-section"
       >
@@ -187,7 +162,7 @@ export default function Home() {
       </section>
 
       <section
-        className="-mx-6 bg-black px-6 py-14 sm:-mx-8 sm:px-8"
+        className="-mx-6 flex min-h-screen items-center bg-black px-6 py-14 sm:-mx-8 sm:px-8"
         aria-labelledby="education-title"
         data-testid="education-section"
       >
@@ -237,9 +212,14 @@ export default function Home() {
                   {item.description}
                 </p>
 
-                <p className="mt-6 text-xs sm:text-sm uppercase tracking-wide text-gray-400">
+                <a
+                  href="https://minderacodeacademy.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-6 inline-block text-xs sm:text-sm uppercase tracking-wide text-gray-400 underline underline-offset-4 hover:text-yellow-400"
+                >
                   Mindera Code Academy
-                </p>
+                </a>
               </article>
             ))}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,78 @@
 'use client';
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import LinkButton from './components/Button/LinkButton';
 import LoadingSpinner from './components/Loading/Loading';
+
+const TESTIMONIALS = [
+  {
+    image:
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1729379516/BUGBUSTER/kkyesbujstwuciybdgsp.jpg',
+    alt: 'Karina Yamashita - Engineer who transitioned into software testing.',
+    title: 'A complete learning journey',
+    quote:
+      'Bruno is an exceptional mentor. Taking part in the mentorship has been a complete learning journey, where theory meets practice in a dynamic and inspiring way. Besides gaining new skills, I developed a stronger testing mindset. Highly recommended!',
+    author:
+      'Karina Yamashita - Engineer who transitioned into software testing',
+  },
+  {
+    image:
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1729446850/mypr5cj8jmyp2heemar5.jpg',
+    alt: 'Raquel Gomes - Phone retail store manager who transitioned into software testing.',
+    title: 'Essential for my QA perspective',
+    quote:
+      'With clear teaching and practical examples, Bruno simplified complex concepts and helped me apply good practices, which increased my confidence. He also tailored the mentorship to my needs, and that made all the difference in my learning.',
+    author:
+      'Raquel Gomes - Phone retail store manager who transitioned into software testing',
+  },
+  {
+    image:
+      'https://res.cloudinary.com/dtglidvcw/image/upload/v1729337224/BUGBUSTER/nbgn3mztpbf1lwzdskld.jpg',
+    alt: 'Luís Moreira - MSc in Electrical Engineering, autistic person with Asperger syndrome.',
+    title: 'Great mentor, excellent friend',
+    quote:
+      'Since I started working with him, Bruno has not only been a great mentor, but also become an excellent friend. We have learned a lot from each other.',
+    author:
+      'Luís Moreira - MSc in Electrical Engineering, autistic person with Asperger syndrome',
+  },
+];
+
+const EDUCATION_ITEMS = [
+  {
+    title: 'Warm Up Manual Testing',
+    year: '2025',
+    status: 'Completed',
+    description:
+      'Introductory course focused on manual testing foundations, core quality concepts, and practical testing mindset development.',
+  },
+  {
+    title: 'Warm Up Automated Tests - Playwright',
+    year: '2025',
+    status: 'Completed',
+    description:
+      'Hands-on course covering automated testing with Playwright, helping students build confidence with modern browser automation.',
+  },
+  {
+    title: 'Backend Testing - Postman + Playwright',
+    year: 'April 13 - May 6, 2026',
+    status: 'Current',
+    description:
+      'Course focused on backend testing practices using Postman and Playwright, combining API validation with practical automation workflows.',
+  },
+  {
+    title: 'Non-Functional Tests',
+    year: 'September 2026',
+    status: 'In progress',
+    description:
+      'Ongoing course exploring non-functional testing topics such as performance, accessibility, and broader quality characteristics.',
+  },
+];
+
+const educationStatusStyles: Record<string, string> = {
+  Completed: 'border-green-500 text-green-400 bg-green-500/10',
+  Current: 'border-yellow-500 text-yellow-400 bg-yellow-500/10',
+  'In progress': 'border-red-500 text-red-400 bg-red-500/10',
+};
 
 export default function Home() {
   const [isLoading, setIsLoading] = useState(true);
@@ -29,35 +100,151 @@ export default function Home() {
 
   return (
     <main
-      className="flex items-center justify-center min-h-[85vh] p-8"
+      className="min-h-[85vh] px-6 pt-10 sm:px-8"
       role="main"
       aria-labelledby="page-title"
     >
-      <div
-        className="text-center sm:text-center max-w-5xl mx-auto"
-        data-testid="home-container"
-      >
-        <h1
-          id="page-title"
-          className="text-5xl sm:text-6xl font-bold text-yellow-500 mb-6"
-          data-testid="home-title"
-        >
-          Welcome to my Portfolio
-        </h1>
-        <p
-          className="text-lg sm:text-2xl mb-8"
-          data-testid="home-description"
-          aria-label="Introduction to portfolio content"
-        >
-          Explore my skills, experience, and projects as a QA Engineer.
-        </p>
-        <LinkButton
-          text="Start here"
-          href="/about"
-          data-testid="home-start-button"
-          aria-label="Navigate to About page"
-        />
+      <div className="max-w-6xl mx-auto" data-testid="home-container">
+        <section className="flex min-h-[78vh] sm:min-h-[82vh] items-center justify-center">
+          <div className="text-center max-w-5xl">
+            <h1
+              id="page-title"
+              className="text-5xl sm:text-6xl font-bold text-yellow-500 mb-6"
+              data-testid="home-title"
+            >
+              Welcome to my Portfolio
+            </h1>
+            <p
+              className="text-lg sm:text-2xl mb-8"
+              data-testid="home-description"
+              aria-label="Introduction to portfolio content"
+            >
+              Explore my skills, experience, projects, and community work as a
+              QA Engineer.
+            </p>
+            <LinkButton
+              text="Start here"
+              href="/about"
+              data-testid="home-start-button"
+              aria-label="Navigate to About page"
+            />
+          </div>
+        </section>
       </div>
+
+      <section
+        className="-mx-6 bg-gradient-to-b from-black via-[rgba(250,204,21,0.88)] to-black px-6 py-10 text-white sm:-mx-8 sm:px-8 sm:py-12"
+        aria-labelledby="testimonials-title"
+        data-testid="testimonials-section"
+      >
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-10">
+            <h2
+              id="testimonials-title"
+              className="text-3xl sm:text-4xl font-bold text-white"
+            >
+              Testimonials
+            </h2>
+            <p className="text-sm sm:text-lg text-white/85 mt-3 max-w-3xl mx-auto">
+              A few words from people I have supported through mentorship and
+              learning journeys in software quality.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-6 max-w-4xl mx-auto">
+            {TESTIMONIALS.map((testimonial) => (
+              <article
+                key={testimonial.author}
+                className="rounded-2xl border-4 border-black bg-black p-6 sm:p-8 shadow-[0_12px_30px_rgba(0,0,0,0.2)]"
+                data-testid={`testimonial-${testimonial.author
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, '-')}`}
+              >
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-5">
+                  <div className="relative h-20 w-20 overflow-hidden rounded-full border-2 border-black">
+                    <Image
+                      src={testimonial.image}
+                      alt={testimonial.alt}
+                      fill
+                      className="object-cover"
+                      sizes="80px"
+                    />
+                  </div>
+                  <h3 className="text-xl font-bold text-white leading-snug">
+                    {testimonial.title}
+                  </h3>
+                </div>
+
+                <blockquote className="text-white/90 text-sm sm:text-base leading-7">
+                  &ldquo;{testimonial.quote}&rdquo;
+                </blockquote>
+
+                <p className="mt-5 text-sm text-yellow-400">{testimonial.author}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="-mx-6 bg-black px-6 py-14 sm:-mx-8 sm:px-8"
+        aria-labelledby="education-title"
+        data-testid="education-section"
+      >
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-10">
+            <h2
+              id="education-title"
+              className="text-3xl sm:text-4xl font-bold text-yellow-500"
+            >
+              Education
+            </h2>
+            <p className="text-sm sm:text-lg text-gray-300 mt-3 max-w-3xl mx-auto">
+              Courses delivered through Mindera Code Academy, focused on
+              building practical software quality skills.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {EDUCATION_ITEMS.map((item) => (
+              <article
+                key={`${item.title}-${item.year}`}
+                className="rounded-2xl border border-yellow-500/70 bg-neutral-950 p-6 sm:p-8"
+                data-testid={`education-${item.title
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, '-')}`}
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-xl sm:text-2xl font-bold text-white">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-sm sm:text-base text-gray-400">
+                      {item.year}
+                    </p>
+                  </div>
+                  <span
+                    className={`inline-flex w-fit rounded-full border px-3 py-1 text-xs uppercase tracking-wide ${
+                      educationStatusStyles[item.status] ??
+                      'border-gray-500 text-gray-300 bg-gray-500/10'
+                    }`}
+                  >
+                    {item.status}
+                  </span>
+                </div>
+
+                <p className="mt-5 text-sm sm:text-base leading-7 text-gray-200">
+                  {item.description}
+                </p>
+
+                <p className="mt-6 text-xs sm:text-sm uppercase tracking-wide text-gray-400">
+                  Mindera Code Academy
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,32 +1,18 @@
 'use client';
 
 import Image from 'next/image';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { PROJECTS } from '../content/projects';
 import { projectStyles } from '../styles/projectStyles';
 import LinkButton from '../components/Button/LinkButton';
-import LoadingSpinner from '../components/Loading/Loading';
 
 export default function ProjectsPage() {
-  const [isClient, setIsClient] = useState(false);
   const [openSection, setOpenSection] = useState<string | null>(null);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
   const toggleSection = (title: string, sectionIndex: number) => {
     const key = `${title}-${sectionIndex}`;
-    setOpenSection(openSection === key ? null : key);
+    setOpenSection((currentSection) => (currentSection === key ? null : key));
   };
-
-  if (!isClient) {
-    return (
-      <div>
-        <LoadingSpinner />
-      </div>
-    );
-  }
 
   return (
     <main
@@ -98,8 +84,9 @@ export default function ProjectsPage() {
                   }`}
                   data-testid={`project-section-${projectIndex}-${sectionIndex}`}
                 >
-                  <div
-                    className="flex justify-between items-center cursor-pointer"
+                  <button
+                    type="button"
+                    className="flex w-full justify-between items-center text-left"
                     onClick={() => toggleSection(project.title, sectionIndex)}
                     aria-expanded={
                       openSection === `${project.title}-${sectionIndex}`
@@ -119,7 +106,7 @@ export default function ProjectsPage() {
                     >
                       ▼
                     </span>
-                  </div>
+                  </button>
                   {openSection === `${project.title}-${sectionIndex}` && (
                     <div
                       id={`section-content-${projectIndex}-${sectionIndex}`}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -65,7 +65,9 @@ export default function ProjectsPage() {
                 alt={`${project.title} logo`}
                 width={300}
                 height={300}
-                className="rounded-lg"
+                className={`rounded-lg object-contain ${
+                  project.logoClassName ?? ''
+                }`}
                 aria-labelledby={`project-title-${projectIndex}`}
               />
             </div>
@@ -134,17 +136,17 @@ export default function ProjectsPage() {
         ))}
       </div>
 
-      {/* Go to Posts Button */}
+      {/* Go to Talks Button */}
       <div
         className="mt-8"
-        data-testid="posts-button-container"
-        aria-label="Navigate to Posts Page"
+        data-testid="talks-button-container"
+        aria-label="Navigate to Talks page"
       >
         <LinkButton
-          text="Go to Posts"
-          href="/posts"
-          data-testid="posts-button"
-          aria-label="Go to Posts page"
+          text="Go to Talks"
+          href="/talks"
+          data-testid="talks-button"
+          aria-label="Go to Talks page"
         />
       </div>
     </main>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,30 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { EXPERIENCES } from '../content/experiences';
 import LinkButton from '../components/Button/LinkButton';
-import LoadingSpinner from '../components/Loading/Loading';
 
 export default function Resume() {
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => setIsLoading(false), 500);
-    return () => clearTimeout(timeout);
-  }, []);
-
-  if (isLoading) {
-    return (
-      <main
-        className="flex items-center justify-center min-h-screen"
-        aria-label="Loading Resume"
-      >
-        <LoadingSpinner />
-      </main>
-    );
-  }
-
   return (
     <main
       className="flex flex-col items-center min-h-screen p-8"

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,20 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import SkillButton from '../components/Button/SkillButton';
 import { SKILLS } from '../content/skills';
 import LinkButton from '../components/Button/LinkButton';
-import LoadingSpinner from '../components/Loading/Loading';
 
 export default function SkillsPage() {
   const [selectedTab, setSelectedTab] = useState<string>('All'); // Default tab
   const [activeSkill, setActiveSkill] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => setIsLoading(false), 500); // Simulating data loading
-    return () => clearTimeout(timeout);
-  }, []);
 
   const categories =
     selectedTab === 'All'
@@ -27,17 +20,6 @@ export default function SkillsPage() {
   const handleSkillClick = (skill: string) => {
     setActiveSkill((prev) => (prev === skill ? null : skill));
   };
-
-  if (isLoading) {
-    return (
-      <main
-        className="flex items-center justify-center min-h-screen"
-        aria-label="Loading Skills"
-      >
-        <LoadingSpinner />
-      </main>
-    );
-  }
 
   return (
     <main

--- a/src/app/styles/projectStyles.ts
+++ b/src/app/styles/projectStyles.ts
@@ -1,4 +1,5 @@
 export const projectStyles: Record<string, string> = {
+  AdventurersGuild: 'border-[#D6B06A] border-8 bg-[#F6E7C8] text-[#2F190F]',
   BugBuster: 'border-white border-8 text-white',
   Petsauro: 'border-green-800 border-8 bg-gray-100 text-green-800',
   Playground: 'border-gray-100 border-8 bg-gray-800 text-gray-100',

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import LinkButton from '../components/Button/LinkButton';
 
 interface TalkImage {
@@ -203,6 +203,9 @@ export default function TalksPage() {
   const [expandedTalks, setExpandedTalks] = useState<Record<number, boolean>>(
     {}
   );
+  const modalCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+  const previousBodyOverflowRef = useRef<string>('');
 
   const allTags = Array.from(
     new Set(SORTED_TALKS.flatMap((talk) => talk.tags))
@@ -254,9 +257,15 @@ export default function TalksPage() {
       return;
     }
 
+    previousFocusedElementRef.current = document.activeElement as HTMLElement | null;
+    previousBodyOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    modalCloseButtonRef.current?.focus();
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setSelectedImage(null);
+        return;
       }
 
       if (event.key === 'ArrowLeft') {
@@ -278,6 +287,35 @@ export default function TalksPage() {
           talkIndex: selectedImage.talkIndex,
           imageIndex: nextIndex,
         });
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const focusableElements = [
+          modalCloseButtonRef.current,
+          document.querySelector<HTMLButtonElement>(
+            '[data-testid="talk-image-modal-prev"]'
+          ),
+          document.querySelector<HTMLButtonElement>(
+            '[data-testid="talk-image-modal-next"]'
+          ),
+        ].filter((element): element is HTMLButtonElement => element !== null);
+
+        if (focusableElements.length === 0) {
+          return;
+        }
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+        const activeElement = document.activeElement;
+
+        if (event.shiftKey && activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        } else if (!event.shiftKey && activeElement === lastElement) {
+          event.preventDefault();
+          firstElement.focus();
+        }
       }
     };
 
@@ -285,6 +323,8 @@ export default function TalksPage() {
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousBodyOverflowRef.current;
+      previousFocusedElementRef.current?.focus();
     };
   }, [filteredTalks, selectedImage]);
 
@@ -480,6 +520,7 @@ export default function TalksPage() {
               onClick={() => setSelectedImage(null)}
               aria-label="Close expanded image"
               data-testid="talk-image-modal-close"
+              ref={modalCloseButtonRef}
             >
               ×
             </button>

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -1,0 +1,526 @@
+'use client';
+
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import LinkButton from '../components/Button/LinkButton';
+
+interface TalkImage {
+  src: string;
+  alt: string;
+}
+
+interface Talk {
+  title: string;
+  event: string;
+  date: string;
+  location?: string;
+  description: string;
+  tags: string[];
+  gallery: TalkImage[];
+}
+
+const TALKS: Talk[] = [
+  {
+    title: 'The Death of the Test Analyst',
+    event: 'BrowserStack QA Meetup - Lisbon',
+    date: 'February 11, 2026',
+    location:
+      'Simplifae - R. Gen. Firmino Miguel 6 Floor -2, Escritório B, 1600-300 Lisbon',
+    description:
+      'A playful investigative talk about the evolution of QA, using the idea of discovering the suspects and cause of death of the Test Analyst to explore how the role has moved beyond a traditional model into a more strategic, technical, and collaborative position.',
+    tags: ['Quality', 'Career', 'Community'],
+    gallery: [
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029257/Portifolio/eventos/Browser%20Stack/1770987240733_xmuydp.jpg',
+        alt: 'Bruno dressed as an investigator during The Death of the Test Analyst talk at the BrowserStack QA Meetup in Lisbon.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029260/Portifolio/eventos/Browser%20Stack/1770987238196_lktvkz.jpg',
+        alt: 'Bruno looking at the audience with a slide in the background saying tester not found during The Death of the Test Analyst talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029260/Portifolio/eventos/Browser%20Stack/1770987243430_sgq2z7.jpg',
+        alt: 'Bruno speaking about older testing tools such as QTP and Selenium during The Death of the Test Analyst talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029259/Portifolio/eventos/Browser%20Stack/1770987243084_glwlvr.jpg',
+        alt: 'Bruno standing in front of slides for The Death of the Test Analyst talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029258/Portifolio/eventos/Browser%20Stack/1770987242906_ryvvm4.jpg',
+        alt: 'Bruno standing in front of slides about tester powers during The Death of the Test Analyst talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029258/Portifolio/eventos/Browser%20Stack/1770987233918_nb0s2d.jpg',
+        alt: 'Slide showing a timeline from the early era of software testing to 2007, when Bruno entered the field.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029258/Portifolio/eventos/Browser%20Stack/1770987236230_ahnx25.jpg',
+        alt: 'Slide showing how many different roles currently exist in the software testing field.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029258/Portifolio/eventos/Browser%20Stack/1770987242879_njawqv.jpg',
+        alt: 'Slide showing the phrase test is dead attributed to the former Chief Technology Officer of Google.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777029257/Portifolio/eventos/Browser%20Stack/1770987241230_zualn4.jpg',
+        alt: 'Mindera gifts prepared to be distributed to participants at the BrowserStack QA Meetup in Lisbon.',
+      },
+    ],
+  },
+  {
+    title: 'The Journey of Software Quality',
+    event: 'Tugágil',
+    date: 'November 6, 2025',
+    location: 'Sonae Tech Hub',
+    description:
+      'A talk about the evolution of software quality from its early stages to the present day, sharing my perspective on how quality has changed over time and the lessons I have taken from that journey.',
+    tags: ['Quality', 'Career', 'Community'],
+    gallery: [
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777027731/Portifolio/eventos/Tug%C3%A1gil/C148E8D6-884E-489B-A3FA-2366964F3299_zupzpq.jpg',
+        alt: 'Group photo of the participants seated together at the back after The Journey of Software Quality talk at Tugágil.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777027732/Portifolio/eventos/Tug%C3%A1gil/E11CC28A-945E-47A7-98FB-B53069B48CC7_vierjt.jpg',
+        alt: 'Audience seated and watching The Journey of Software Quality talk at Tugágil.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777027732/Portifolio/eventos/Tug%C3%A1gil/C9AEFA58-33BC-4F33-93E4-D9537B3F0077_zyli6x.jpg',
+        alt: 'Slide from The Journey of Software Quality talk showing the message It is impossible to automate chaos.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777027731/Portifolio/eventos/Tug%C3%A1gil/D87F0DB4-8C53-487D-AD94-0F57FAE44354_mwhrrh.jpg',
+        alt: 'Slide from The Journey of Software Quality talk showing the former Poatek team.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1777027731/Portifolio/eventos/Tug%C3%A1gil/D4DC7C53-EBEF-41F9-BB64-ACBD3C79DB56_zxjt2g.jpg',
+        alt: 'Slide from The Journey of Software Quality talk highlighting that people are more important than tools.',
+      },
+    ],
+  },
+  {
+    title: 'Accessibility Testing',
+    event: 'Mindera Talks',
+    date: 'October 17, 2024',
+    location: 'Mindera',
+    description:
+      'A Mindera Talks session focused on accessibility testing, covering inclusive design considerations, contrast rules, and practical examples supported by participants and the community.',
+    tags: ['Accessibility', 'Quality', 'Community'],
+    gallery: [
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467114/BUGBUSTER/Mindera%20Talk/ivmkykxffo0v9b1yetvm.jpg',
+        alt: 'Presentation slide about different types of limitations during the Accessibility Testing talk at Mindera.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467384/BUGBUSTER/Mindera%20Talk/o2gjtwyxiymdeupcbz7h.jpg',
+        alt: 'People gathering in the kitchen area before the Accessibility Testing talk at Mindera.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467386/BUGBUSTER/Mindera%20Talk/bn8qiqmbq6hmybccpich.jpg',
+        alt: 'Mindera event space prepared for the Accessibility Testing talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467384/BUGBUSTER/Mindera%20Talk/ri8nncsbwiruxqnju8tx.jpg',
+        alt: 'Two blind participants contributing to the Accessibility Testing event at Mindera.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467212/BUGBUSTER/Mindera%20Talk/iopm9a7wsj1qdzjxqiff.jpg',
+        alt: 'Pantufa watching the Accessibility Testing talk attentively.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467125/BUGBUSTER/Mindera%20Talk/sqhysqmceg7nuyp5hp4t.jpg',
+        alt: 'Pantufa being showered with kisses during the Accessibility Testing event.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467803/BUGBUSTER/Mindera%20Talk/totblztyalok2a2lbf1j.jpg',
+        alt: 'Presentation slide explaining contrast rules during the Accessibility Testing talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729467803/BUGBUSTER/Mindera%20Talk/rikaso5jgbkjazdckobo.jpg',
+        alt: 'Presentation slide showing examples of bad and good buttons during the Accessibility Testing talk.',
+      },
+    ],
+  },
+  {
+    title: 'Software accessibility to everyone',
+    event: '3rd Test Tribe Porto - Infraspeak',
+    date: 'June 12, 2024',
+    description:
+      'A talk focused on making software accessibility more approachable and practical for everyone involved in building digital products.',
+    tags: ['Accessibility', 'Quality', 'Community'],
+    gallery: [
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1718573164/BUGBUSTER/Screenshot_2024-05-27_at_13.30.38_frkmsf.png',
+        alt: 'Promotional image for the Test Tribe talk Software accessibility to everyone, presented in June 2024.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1718577316/BUGBUSTER/WhatsApp_Image_2024-06-12_at_23.14.06_1_xvwdsb.jpg',
+        alt: 'Bruno speaking during the Software accessibility to everyone talk while looking at the presentation screen.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1719503923/BUGBUSTER/pozhytyoxx1odetqgzrm.webp',
+        alt: 'View from the back of the auditorium showing an audience of around 50 people during the Software accessibility to everyone talk.',
+      },
+    ],
+  },
+  {
+    title: 'Security Testing',
+    event: "Tester's Day",
+    date: 'September 9, 2024',
+    location: 'Mindera',
+    description:
+      'A talk about security testing shared during Dia do Testador, followed by QA community moments at Mindera.',
+    tags: ['Security', 'Quality', 'Community'],
+    gallery: [
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729466684/BUGBUSTER/testes_de_seguran%C3%A7a/securitytests.jpg',
+        alt: 'Photo from Dia do Testador at Mindera during the Security Testing talk.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729466692/BUGBUSTER/testes_de_seguran%C3%A7a/almo%C3%A7o.jpg',
+        alt: 'QA Gatherings lunch during Dia do Testador at Mindera.',
+      },
+      {
+        src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1729466683/BUGBUSTER/testes_de_seguran%C3%A7a/cdhtmdckccu2b1o6q3wu.jpg',
+        alt: 'Pantufa at the QA Gatherings lunch during Dia do Testador at Mindera.',
+      },
+    ],
+  },
+];
+
+const SORTED_TALKS = [...TALKS].sort(
+  (firstTalk, secondTalk) =>
+    new Date(secondTalk.date).getTime() - new Date(firstTalk.date).getTime()
+);
+
+export default function TalksPage() {
+  const [selectedImage, setSelectedImage] = useState<{
+    talkIndex: number;
+    imageIndex: number;
+  } | null>(null);
+  const [selectedTag, setSelectedTag] = useState<string>('All');
+  const [expandedTalks, setExpandedTalks] = useState<Record<number, boolean>>(
+    {}
+  );
+
+  const allTags = Array.from(
+    new Set(SORTED_TALKS.flatMap((talk) => talk.tags))
+  ).sort((firstTag, secondTag) => firstTag.localeCompare(secondTag));
+  const tags = ['All', ...allTags];
+  const filteredTalks =
+    selectedTag === 'All'
+      ? SORTED_TALKS
+      : SORTED_TALKS.filter((talk) => talk.tags.includes(selectedTag));
+
+  const selectedTalk =
+    selectedImage !== null ? filteredTalks[selectedImage.talkIndex] : null;
+  const selectedGalleryImage =
+    selectedTalk && selectedImage !== null
+      ? selectedTalk.gallery[selectedImage.imageIndex]
+      : null;
+
+  const showPreviousImage = () => {
+    if (!selectedImage) {
+      return;
+    }
+
+    const gallery = filteredTalks[selectedImage.talkIndex].gallery;
+    const previousIndex =
+      (selectedImage.imageIndex - 1 + gallery.length) % gallery.length;
+
+    setSelectedImage({
+      talkIndex: selectedImage.talkIndex,
+      imageIndex: previousIndex,
+    });
+  };
+
+  const showNextImage = () => {
+    if (!selectedImage) {
+      return;
+    }
+
+    const gallery = filteredTalks[selectedImage.talkIndex].gallery;
+    const nextIndex = (selectedImage.imageIndex + 1) % gallery.length;
+
+    setSelectedImage({
+      talkIndex: selectedImage.talkIndex,
+      imageIndex: nextIndex,
+    });
+  };
+
+  useEffect(() => {
+    if (!selectedImage) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedImage(null);
+      }
+
+      if (event.key === 'ArrowLeft') {
+        const gallery = filteredTalks[selectedImage.talkIndex].gallery;
+        const previousIndex =
+          (selectedImage.imageIndex - 1 + gallery.length) % gallery.length;
+
+        setSelectedImage({
+          talkIndex: selectedImage.talkIndex,
+          imageIndex: previousIndex,
+        });
+      }
+
+      if (event.key === 'ArrowRight') {
+        const gallery = filteredTalks[selectedImage.talkIndex].gallery;
+        const nextIndex = (selectedImage.imageIndex + 1) % gallery.length;
+
+        setSelectedImage({
+          talkIndex: selectedImage.talkIndex,
+          imageIndex: nextIndex,
+        });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [filteredTalks, selectedImage]);
+
+  useEffect(() => {
+    setSelectedImage(null);
+  }, [selectedTag]);
+
+  return (
+    <>
+      <main
+        className="flex flex-col items-center min-h-screen p-4 sm:p-8"
+        data-testid="talks-page"
+        role="main"
+        aria-labelledby="talks-page-title"
+      >
+        <div className="w-full max-w-6xl">
+          <h1
+            id="talks-page-title"
+            className="text-4xl sm:text-5xl font-bold text-yellow-500 mb-8 text-center"
+            data-testid="talks-title"
+          >
+            Talks
+          </h1>
+
+          <div
+            className="mb-6 w-full max-w-5xl px-4"
+            data-testid="talks-filter-tags-container"
+          >
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4 justify-center">
+              {tags.map((tag, index) => (
+                <button
+                  key={index}
+                  className={`inline-block px-3 py-1 sm:px-4 sm:pt-2 text-sm sm:text-lg font-semibold border-b-2 text-center ${
+                    selectedTag === tag
+                      ? 'text-yellow-500 border-yellow-500'
+                      : 'text-gray-300 border-transparent'
+                  }`}
+                  onClick={() => setSelectedTag(tag)}
+                  data-testid={`talk-filter-tag-${tag.toLowerCase().replace(/\s+/g, '-')}`}
+                  aria-pressed={selectedTag === tag}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-8" data-testid="talks-list">
+            {filteredTalks.map((talk, talkIndex) => (
+              <article
+                key={talk.title}
+                className="border border-yellow-500 rounded-lg p-6 sm:p-8"
+                data-testid={`talk-card-${talkIndex}`}
+              >
+                <div className="mb-6">
+                <p className="text-yellow-500 text-sm sm:text-base font-semibold uppercase tracking-wide">
+                  {talk.event}
+                </p>
+                <h2
+                  className="text-3xl sm:text-4xl font-bold text-white mt-2"
+                    data-testid={`talk-title-${talkIndex}`}
+                  >
+                    {talk.title}
+                  </h2>
+                <p
+                  className="text-gray-400 text-sm sm:text-base mt-2"
+                  data-testid={`talk-date-${talkIndex}`}
+                >
+                  {talk.date}
+                </p>
+                {talk.location && (
+                  <p className="text-gray-400 text-sm sm:text-base mt-1">
+                    {talk.location}
+                  </p>
+                )}
+                <p className="text-white text-base sm:text-lg mt-4 max-w-4xl">
+                  {talk.description}
+                </p>
+                <div
+                  className="flex flex-wrap gap-2 mt-4"
+                  data-testid={`talk-tags-${talkIndex}`}
+                >
+                  {talk.tags.map((tag, tagIndex) => (
+                    <span
+                      key={tagIndex}
+                      className="bg-yellow-500 text-black text-sm px-3 py-1 rounded"
+                      data-testid={`talk-tag-${talkIndex}-${tagIndex}`}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                </div>
+
+                <div
+                  className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+                  data-testid={`talk-gallery-${talkIndex}`}
+                >
+                  {(expandedTalks[talkIndex]
+                    ? talk.gallery
+                    : talk.gallery.slice(0, 3)
+                  ).map((image, imageIndex) => (
+                    <div
+                      key={image.src}
+                      className="overflow-hidden rounded-lg bg-neutral-950"
+                      data-testid={`talk-gallery-item-${talkIndex}-${imageIndex}`}
+                    >
+                      <button
+                        type="button"
+                        className="block relative w-full h-52 sm:h-60 cursor-zoom-in"
+                        onClick={() =>
+                          setSelectedImage({
+                            talkIndex,
+                            imageIndex: expandedTalks[talkIndex]
+                              ? imageIndex
+                              : talk.gallery.findIndex(
+                                  (galleryImage) => galleryImage.src === image.src
+                                ),
+                          })
+                        }
+                        aria-label={`Open image: ${image.alt}`}
+                        data-testid={`talk-gallery-button-${talkIndex}-${imageIndex}`}
+                      >
+                        <Image
+                          src={image.src}
+                          alt={image.alt}
+                          fill
+                          className="object-cover transition-transform duration-300 hover:scale-105"
+                          sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
+                        />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                {talk.gallery.length > 3 && (
+                  <div className="mt-4 flex justify-center">
+                    <button
+                      type="button"
+                      className="rounded-full border border-yellow-500 px-5 py-2 text-sm text-yellow-400 transition hover:bg-yellow-500 hover:text-black"
+                      onClick={() =>
+                        setExpandedTalks((currentState) => ({
+                          ...currentState,
+                          [talkIndex]: !currentState[talkIndex],
+                        }))
+                      }
+                      data-testid={`talk-gallery-toggle-${talkIndex}`}
+                    >
+                      {expandedTalks[talkIndex] ? 'Show fewer photos' : 'Show more photos'}
+                    </button>
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className="w-1/4 border-t border-gray-500 opacity-50 mt-12 mb-8"
+          aria-hidden="true"
+          data-testid="talks-divider"
+        />
+
+        <div
+          data-testid="posts-button-container"
+          aria-label="Navigate to Posts page"
+        >
+          <LinkButton
+            text="Go to Posts"
+            href="/posts"
+            data-testid="posts-button"
+            aria-label="Go to Posts page"
+          />
+        </div>
+      </main>
+
+      {selectedGalleryImage && (
+        <div
+          className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4 sm:p-8"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Expanded talk image"
+          data-testid="talk-image-modal"
+          onClick={() => setSelectedImage(null)}
+        >
+          <div
+            className="relative w-full max-w-6xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="absolute -top-12 right-0 text-white text-3xl leading-none"
+              onClick={() => setSelectedImage(null)}
+              aria-label="Close expanded image"
+              data-testid="talk-image-modal-close"
+            >
+              ×
+            </button>
+
+            <button
+              type="button"
+              className="absolute -left-20 top-1/2 z-10 -translate-y-1/2 flex h-14 w-14 items-center justify-center rounded-full border border-yellow-500 bg-[#2F190F]/80 text-yellow-400 text-2xl backdrop-blur-sm transition-transform hover:scale-105 hover:bg-[#4A2A1A]/85"
+              onClick={showPreviousImage}
+              aria-label="Show previous image"
+              data-testid="talk-image-modal-prev"
+            >
+              ←
+            </button>
+
+            <button
+              type="button"
+              className="absolute -right-20 top-1/2 z-10 -translate-y-1/2 flex h-14 w-14 items-center justify-center rounded-full border border-yellow-500 bg-[#2F190F]/80 text-yellow-400 text-2xl backdrop-blur-sm transition-transform hover:scale-105 hover:bg-[#4A2A1A]/85"
+              onClick={showNextImage}
+              aria-label="Show next image"
+              data-testid="talk-image-modal-next"
+            >
+              →
+            </button>
+
+            <div className="relative w-full h-[70vh] rounded-lg overflow-hidden bg-black">
+              <Image
+                src={selectedGalleryImage.src}
+                alt={selectedGalleryImage.alt}
+                fill
+                className="object-contain"
+                sizes="100vw"
+                priority
+              />
+            </div>
+
+            <p className="mt-4 text-sm sm:text-base text-gray-200 text-center">
+              {selectedGalleryImage.alt}
+            </p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/tests/about.spec.ts
+++ b/tests/about.spec.ts
@@ -37,4 +37,20 @@ test.describe('About Page', () => {
       });
     }
   });
+
+  test('Section keyboard interaction', async ({ page }) => {
+    const aboutPage = new AboutPage(page);
+
+    await aboutPage.navigateToAbout();
+    await aboutPage.validatePageLoaded();
+
+    await test.step('Open first section with keyboard', async () => {
+      await aboutPage.focusSectionToggle(0);
+      await page.keyboard.press('Enter');
+      await aboutPage.validateSectionContentVisible(
+        0,
+        ABOUT_DATA.sections[0].content
+      );
+    });
+  });
 });

--- a/tests/data/test-data.ts
+++ b/tests/data/test-data.ts
@@ -1,8 +1,22 @@
 // Home Page Data
 export const HOME_DATA = {
   title: 'Welcome to my Portfolio',
-  subtitle: 'Explore my skills, experience, and projects as a QA Engineer.',
+  subtitle:
+    'Explore my skills, experience, projects, and community work as a QA Engineer.',
   startButtonText: 'Start here',
+  testimonialsTitle: 'Testimonials',
+  educationTitle: 'Education',
+  testimonialTitles: [
+    'A complete learning journey',
+    'Essential for my QA perspective',
+    'Great mentor, excellent friend',
+  ],
+  educationTitles: [
+    'Warm Up Manual Testing',
+    'Warm Up Automated Tests - Playwright',
+    'Backend Testing - Postman + Playwright',
+    'Non-Functional Tests',
+  ],
 };
 
 // Footer Data
@@ -18,6 +32,7 @@ export const HEADER_DATA = {
     'resume',
     'skills',
     'projects',
+    'talks',
     'posts',
     'contacts',
   ],

--- a/tests/footer.spec.ts
+++ b/tests/footer.spec.ts
@@ -21,7 +21,7 @@ test.describe('Footer', () => {
     }
 
     await test.step('Copyright', async () => {
-      await footerPage.validateCopyrightText('© 2024 Bruno Machado.');
+      await footerPage.validateCurrentYearCopyright();
     });
   });
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -20,5 +20,15 @@ test.describe('Home', () => {
     await test.step('Check Start Button', async () => {
       await homePage.validateStartButtonVisible();
     });
+
+    await test.step('Check Testimonials Section', async () => {
+      await homePage.validateTestimonialsSectionVisible();
+      await homePage.validateTestimonialCardsVisible();
+    });
+
+    await test.step('Check Education Section', async () => {
+      await homePage.validateEducationSectionVisible();
+      await homePage.validateEducationCardsVisible();
+    });
   });
 });

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -14,6 +14,10 @@ test.describe('Menu', () => {
 
     if (isMobile) {
       for (const option of mobileMenuOptions) {
+        await test.step(`Go Home For Mobile: ${option}`, async () => {
+          await menuPage.navigateToHome();
+        });
+
         await test.step(`Open Mobile: ${option}`, async () => {
           await menuPage.openMobileMenu();
         });

--- a/tests/pages/AboutPage.ts
+++ b/tests/pages/AboutPage.ts
@@ -40,7 +40,7 @@ export class AboutPage {
   }
 
   async clickSession(index: number) {
-    const session = this.page.getByTestId(`section-${index}`);
+    const session = this.page.getByTestId(`section-toggle-${index}`);
     await session.click();
 
     const contentLocator = this.page.getByTestId(`section-content-${index}`);
@@ -49,6 +49,10 @@ export class AboutPage {
       await session.click();
       await this.page.waitForTimeout(300);
     }
+  }
+
+  async focusSectionToggle(index: number) {
+    await this.page.getByTestId(`section-toggle-${index}`).focus();
   }
 
   async validateSectionTitleVisible(index: number, expectedTitle: string) {

--- a/tests/pages/FooterPage.ts
+++ b/tests/pages/FooterPage.ts
@@ -20,11 +20,14 @@ export class FooterPage {
   async validateLinkVisible(linkTestId: string) {
     const link = this.page.getByTestId(`footer-link-${linkTestId}`);
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute('href', expect.stringContaining('http'));
+    const expectedHref =
+      linkTestId === 'email' ? expect.stringContaining('mailto:') : expect.stringContaining('http');
+    await expect(link).toHaveAttribute('href', expectedHref);
   }
 
-  async validateCopyrightText(expectedText: string) {
+  async validateCurrentYearCopyright() {
+    const currentYear = new Date().getFullYear();
     await expect(this.copyrightText).toBeVisible();
-    await expect(this.copyrightText).toHaveText(expectedText);
+    await expect(this.copyrightText).toHaveText(`© ${currentYear} Bruno Machado.`);
   }
 }

--- a/tests/pages/HomePage.ts
+++ b/tests/pages/HomePage.ts
@@ -6,12 +6,16 @@ export class HomePage {
   readonly titleLocator: Locator;
   readonly subtitleLocator: Locator;
   readonly startButtonLocator: Locator;
+  readonly testimonialsSectionLocator: Locator;
+  readonly educationSectionLocator: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.titleLocator = page.getByTestId('home-title');
     this.subtitleLocator = page.getByTestId('home-description');
     this.startButtonLocator = page.getByTestId('home-start-button');
+    this.testimonialsSectionLocator = page.getByTestId('testimonials-section');
+    this.educationSectionLocator = page.getByTestId('education-section');
   }
 
   async navigateToHome() {
@@ -31,5 +35,35 @@ export class HomePage {
   async validateStartButtonVisible() {
     await expect(this.startButtonLocator).toBeVisible();
     await expect(this.startButtonLocator).toHaveText(HOME_DATA.startButtonText);
+  }
+
+  async validateTestimonialsSectionVisible() {
+    await expect(this.testimonialsSectionLocator).toBeVisible();
+    await expect(
+      this.page.getByRole('heading', { name: HOME_DATA.testimonialsTitle })
+    ).toBeVisible();
+  }
+
+  async validateTestimonialCardsVisible() {
+    for (const title of HOME_DATA.testimonialTitles) {
+      await expect(
+        this.testimonialsSectionLocator.getByRole('heading', { name: title })
+      ).toBeVisible();
+    }
+  }
+
+  async validateEducationSectionVisible() {
+    await expect(this.educationSectionLocator).toBeVisible();
+    await expect(
+      this.page.getByRole('heading', { name: HOME_DATA.educationTitle })
+    ).toBeVisible();
+  }
+
+  async validateEducationCardsVisible() {
+    for (const title of HOME_DATA.educationTitles) {
+      await expect(
+        this.educationSectionLocator.getByRole('heading', { name: title })
+      ).toBeVisible();
+    }
   }
 }

--- a/tests/pages/MenuPage.ts
+++ b/tests/pages/MenuPage.ts
@@ -24,12 +24,25 @@ export class MenuPage {
   async validateURL(menuItem: string) {
     const expectedURL = menuItem === 'home' ? '/' : `/${menuItem}`;
     await expect(this.page).toHaveURL(expectedURL);
+    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForTimeout(300);
   }
 
   async openMobileMenu() {
-    const toggle = await this.page.getByTestId('menu-toggle');
-    await this.page.waitForTimeout(300);
-    await toggle.click();
+    const toggle = this.page.getByTestId('menu-toggle');
+    await expect(toggle).toBeVisible();
+    const firstMobileItem = this.page.getByTestId('mobile-menu-link-home');
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (await firstMobileItem.isVisible()) {
+        break;
+      }
+
+      await toggle.tap();
+      await this.page.waitForTimeout(400);
+    }
+
+    await expect(firstMobileItem).toBeVisible();
   }
 
   async validateMobileMenuItemVisible(menuItem: string) {

--- a/tests/pages/MenuPage.ts
+++ b/tests/pages/MenuPage.ts
@@ -8,7 +8,7 @@ export class MenuPage {
   }
 
   async navigateToHome() {
-    await this.page.goto('', { waitUntil: 'commit' });
+    await this.page.goto('', { waitUntil: 'networkidle' });
   }
 
   async validateMenuItemVisible(menuItem: string) {
@@ -30,7 +30,6 @@ export class MenuPage {
 
   async openMobileMenu() {
     const toggle = this.page.getByTestId('menu-toggle');
-    await expect(toggle).toBeVisible();
     const firstMobileItem = this.page.getByTestId('mobile-menu-link-home');
 
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -38,7 +37,11 @@ export class MenuPage {
         break;
       }
 
-      await toggle.tap();
+      await this.page.evaluate(() => window.scrollTo(0, 0));
+      await this.page.waitForTimeout(150);
+      await toggle.scrollIntoViewIfNeeded();
+      await expect(toggle).toBeVisible();
+      await toggle.click();
       await this.page.waitForTimeout(400);
     }
 

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Projects', () => {
+  test('Accordion supports keyboard interaction', async ({ page }) => {
+    await page.goto('/projects', { waitUntil: 'networkidle' });
+
+    const firstToggle = page.getByTestId('section-toggle-0-0');
+    const firstContent = page.getByTestId('section-content-0-0');
+
+    await expect(firstToggle).toBeVisible();
+    await expect(firstContent).toHaveCount(0);
+
+    await firstToggle.press('Enter');
+
+    await expect(firstContent).toBeVisible();
+  });
+});

--- a/tests/talks.spec.ts
+++ b/tests/talks.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Talks', () => {
+  test('Image modal supports focus, keyboard close, and scroll lock', async ({
+    page,
+  }) => {
+    await page.goto('/talks', { waitUntil: 'networkidle' });
+
+    const firstImageButton = page.getByTestId('talk-gallery-button-0-0');
+    const modal = page.getByTestId('talk-image-modal');
+    const closeButton = page.getByTestId('talk-image-modal-close');
+
+    await expect(firstImageButton).toBeVisible();
+    await firstImageButton.scrollIntoViewIfNeeded();
+
+    await firstImageButton.click({ force: true });
+
+    await expect(modal).toBeVisible();
+    await expect(closeButton).toBeFocused();
+    await expect
+      .poll(async () => page.evaluate(() => document.body.style.overflow))
+      .toBe('hidden');
+
+    await page.keyboard.press('Escape');
+
+    await expect(modal).toBeHidden();
+    await expect
+      .poll(async () => page.evaluate(() => document.body.style.overflow))
+      .toBe('');
+  });
+});


### PR DESCRIPTION
**Title**
Expand portfolio with talks, home updates, accessibility improvements, and test coverage

**Description**
This PR expands the portfolio with new content, navigation updates, home page improvements, accessibility fixes, and stronger automated test coverage.

It includes the introduction of a dedicated `Talks` area, updates to the home page to better highlight testimonials and education work, new portfolio content for projects and talks, and a final round of accessibility and performance-oriented refinements.

**What changed**

**Projects**
- Added `Adventurers Guild` as a featured project at the top of the projects list
- Created a dedicated `AdventurersGuild` card style
- Added themed project sections and project link
- Updated the project logo to the final transparent asset
- Adjusted logo presentation so it fills the card more appropriately
- Updated the Projects page CTA to point to `Talks`

**Talks**
- Added a new `Talks` page
- Updated navigation flow so:
  - `Projects` points to `Talks`
  - `Talks` points to `Posts`
- Added multiple talks with:
  - title
  - event
  - date
  - location
  - description
  - image galleries
  - accessible image descriptions
- Added tag support and filtering for talks, following the same pattern used in posts
- Added image modal support with:
  - click to enlarge
  - keyboard navigation with `ArrowLeft`, `ArrowRight`, and `Escape`
  - visible navigation arrows
  - focus management improvements
  - body scroll locking while modal is open
- Reduced visible gallery thumbnails to 3 by default with `Show more photos`

**Experience**
- Updated experience galleries so images can be opened in a modal
- Added keyboard navigation and modal controls similar to the Talks page
- Added an extra image to the `Avios / IAGL Loyalty` gallery
- Improved modal accessibility behavior

**Home page**
- Added a new `Testimonials` section
- Added a new `Education` section highlighting Mindera Code Academy courses
- Added clickable `Mindera Code Academy` links in course cards
- Updated the visual structure of the landing page so sections occupy a full viewport height
- Refined section styling and color transitions to improve hierarchy and emphasis

**Education content added**
- `Warm Up Manual Testing`
- `Warm Up Automated Tests - Playwright`
- `Backend Testing - Postman + Playwright`
- `Non-Functional Tests`

**Accessibility and UX improvements**
- Refactored `LinkButton` so links no longer render nested `button` elements
- Replaced non-semantic clickable containers in accordions with real `button` elements
- Improved keyboard support in expandable sections
- Added focus handling to image modals:
  - focus moves into the modal on open
  - focus is restored on close
  - tab navigation is constrained to modal controls
- Improved mobile menu layering so page content no longer overlaps the opened menu
- Updated footer year to be dynamic

**Performance-oriented improvements**
- Removed artificial loading delays implemented with `setTimeout` on several pages
- Removed unnecessary client-side loading gates where they were not needed
- Updated menu items to use `next/link` navigation behavior

**Tests**
- Updated existing Playwright tests to reflect the latest content and navigation changes
- Added home coverage for:
  - Testimonials
  - Education
- Updated footer tests for dynamic year and `mailto:` handling
- Improved menu test stability, especially on mobile devices
- Added new tests covering:
  - About section keyboard interaction
  - Projects accordion keyboard interaction
  - Talks modal interaction, focus behavior, keyboard close, and scroll lock

**Files impacted**
- `src/app/page.tsx`
- `src/app/talks/page.tsx`
- `src/app/projects/page.tsx`
- `src/app/experience/[companyYear]/page.tsx`
- `src/app/content/projects.tsx`
- `src/app/content/experiences.tsx`
- `src/app/styles/projectStyles.ts`
- `src/app/components/Button/LinkButton.tsx`
- `src/app/components/AboutSections/AboutSections.tsx`
- `src/app/components/Header/*`
- `src/app/components/Footer/Footer.tsx`
- `tests/*`

**Validation**
- `npm run build` passed
- Targeted Playwright coverage for the new accessibility interactions passed

